### PR TITLE
adding virtualisation rules to automaticly visualise vm

### DIFF
--- a/part1/Makefile
+++ b/part1/Makefile
@@ -31,6 +31,7 @@ ASM_OBJ = $(addprefix $(OBJ_DIRECTORY), $(ASM_FILES:.asm=.o))
 C_OBJ = $(addprefix $(OBJ_DIRECTORY), $(C_FILES:.c=.o))
 OBJ = $(ASM_OBJ) $(C_OBJ)
 DEPS := ${OBJ:.o=.d}
+QEMU := /usr/bin/qemu-system-x86_64
 
 CODE_TARGET = $(OBJ_DIRECTORY)$(KERNEL_NAME)$(KERNEL_VERSION)
 
@@ -56,6 +57,9 @@ $(ASM_OBJ): $(OBJ_DIRECTORY)%.o: $(SRC_DIRECTORY)%.asm | $(OBJ_DIRECTORY)
 
 $(C_OBJ): $(OBJ_DIRECTORY)%.o: $(SRC_DIRECTORY)%.c | $(OBJ_DIRECTORY)
 	$(C_COMPILER) $(C_OPTIONS) $< -o $@
+
+virtualisation: all
+	 $(QEMU) -enable-kvm -cdrom $(ISO_TARGET) -m 1G -boot d -serial stdio -monitor pty
 
 clean:
 	-rm $(DEPS)

--- a/part1/install.sh
+++ b/part1/install.sh
@@ -4,7 +4,11 @@ USER=`whoami`
 
 do_install() {
     # KVM
-    sudo apt install qemu-kvm libvirt-daemon-system libvirt-clients bridge-utils -y
+    sudo apt install libvirt-daemon-system libvirt-clients bridge-utils -y
+    sudo apt remove qemu-system-x86 -y
+    sudo apt autoremove -y
+    sudo apt update -y
+    sudo apt install qemu-system-x86 qemu-kvm -y
     sudo adduser ${USER} libvirt
     sudo adduser ${USER} kvm
     # # GRUB
@@ -12,6 +16,7 @@ do_install() {
     # ASM
     sudo apt install nasm
     sudo apt-get install xorriso
+    unset GTK_PATH # Issue with vs code temrminal
 }
 
 


### PR DESCRIPTION
pour eviter de passer par virutal box,
la on fait juste un make virtualisation et normalement ca te lance la vm
Dans le terminal de vs code il faut run cette commande avant : unset GTK_PATH
J'ai essayé de l'integrer au script mais ca marche pas