### PR TITLE
refactor: colors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,7 +36,10 @@
 		"ostream": "c",
 		"sstream": "c",
 		"stdexcept": "c",
-		"streambuf": "c"
+		"streambuf": "c",
+		"cstdint": "c",
+		"types.h": "c",
+		"cursor.h": "c"
 	},
 	"editor.tabSize": 4,
 	"prettier.useTabs": true,

--- a/part1/source/main.c
+++ b/part1/source/main.c
@@ -3,17 +3,28 @@
 
 void print_42(void)
 {
-	print_string("              42424  42424242424\n", BG(RED | INTENSIVE) | BLUE);
-	print_string("           42424     4242  42424\n", BG(BLUE | INTENSIVE) | GREEN);
-	print_string("        42424        42    42424\n", BG(GREEN | INTENSIVE) | RED);
-	print_string("     42424               42424\n", BG(CYAN | INTENSIVE) | YELLOW);
-	print_string("  42424                42424\n", BG(YELLOW | INTENSIVE) | MAGENTA);
-	print_string("4242424242424242424  42424    42\n", BG(MAGENTA | INTENSIVE) | CYAN);
-	print_string("4242424242424242424  42424  4242\n", BG(BLUE | INTENSIVE) | GREEN | INTENSIVE);
-	print_string("               4242  42424242424\n", BG(WHITE | INTENSIVE) | RED | INTENSIVE);
-	print_string("               4242\n", BG(YELLOW | INTENSIVE) | YELLOW | INTENSIVE);
-	print_string("               4242\n", BG(GREEN | INTENSIVE) | MAGENTA | INTENSIVE);
-	print_string("               4242\n", BG(RED | INTENSIVE) | BLUE | INTENSIVE);
+	set_color(&screen_context, BG(RED) | BLUE);
+	print_string("              42424  42424242424\n");
+	set_color(&screen_context, BG(BLUE) | GREEN);
+	print_string("           42424     4242  42424\n");
+	set_color(&screen_context, BG(GREEN) | RED);
+	print_string("        42424        42    42424\n");
+	set_color(&screen_context, BG(CYAN) | YELLOW);
+	print_string("     42424               42424\n");
+	set_color(&screen_context, BG(YELLOW) | MAGENTA);
+	print_string("  42424                42424\n");
+	set_color(&screen_context, BG(MAGENTA) | CYAN);
+	print_string("4242424242424242424  42424    42\n");
+	set_color(&screen_context, BG(BLUE) | GREEN | INTENSIVE);
+	print_string("4242424242424242424  42424  4242\n");
+	set_color(&screen_context, BG(WHITE) | RED | INTENSIVE);
+	print_string("               4242  42424242424\n");
+	set_color(&screen_context, BG(YELLOW) | YELLOW | INTENSIVE);
+	print_string("               4242\n");
+	set_color(&screen_context, BG(GREEN) | MAGENTA | INTENSIVE);
+	print_string("               4242\n");
+	set_color(&screen_context, BG(RED) | BLUE | INTENSIVE);
+	print_string("               4242\n");
 }
 
 void main()
@@ -22,20 +33,25 @@ void main()
 
 	int nb = 8;
 	clear_screen(&screen_context);
-	print_string("hello val ca va ? ", YELLOW);
-	kfs_write_char(&screen_context, '\n', WHITE);
-	kfs_write_char(&screen_context, 'D', GREEN);
-	kfs_write_char(&screen_context, '\n', WHITE);
-	print_number(8988, GREEN);
+	set_color(&screen_context, YELLOW);
+	print_string("hello val ca va ? ");
+	set_color(&screen_context, GREEN);
+	print_char('\n');
+	print_char('D');
+	print_char('\n');
+	print_number(8988);
+	set_color(&screen_context, WHITE);
 	print_f("ceci est un int test %d", 123);
-	kfs_write_char(&screen_context, '\n', WHITE);
+	print_char('\n');
 	print_f("ceci est un char test %c", 'C');
-	kfs_write_char(&screen_context, '\n', WHITE);
+	print_char('\n');
 	int test = print_f("ceci est un string test %s", "frefjreferf");
 	// print_f("ceci est un hex test %x", &nb);
-	print_string("Versiwfwfefewfwefewoweewefwefew\n", RED);
-	print_number(test, GREEN);
+	set_color(&screen_context, RED);
+	print_string("Versiwfwfefewfwefewoweewefwefew\n");
+	set_color(&screen_context, GREEN);
+	print_number(test);
 
-	kfs_write_char(&screen_context, '\n', WHITE);
+	kfs_write_colored_char(&screen_context, '\n', WHITE);
 	print_42();
 }

--- a/part1/source/print_manager.c
+++ b/part1/source/print_manager.c
@@ -1,35 +1,35 @@
 #include "print_manager.h"
 
-int print_string(char *str, unsigned char color)
+int print_string(char *str)
 {
 	int index = 0;
 	while (str[index])
 	{
-		kfs_write_char(&screen_context, str[index], color);
+		kfs_write_char(&screen_context, str[index]);
 		index++;
 	}
 	return index;
 }
 
-int print_number(int nb, unsigned char color)
+int print_number(int nb)
 {
 	int	 len_nb = intlen(nb) + 1;
 	char str[len_nb];
 
 	itoa(nb, str);
-	print_string(str, color);
+	print_string(str);
 	return len_nb;
 }
 
-void print_hex(int hex, unsigned char color)
+void print_hex(int hex)
 {
 	char base[] = "0123456789abcdef";
 	if (hex > HEX_BASE_SIZE - 1)
 	{
-		print_hex(hex / HEX_BASE_SIZE, color);
+		print_hex(hex / HEX_BASE_SIZE);
 		hex %= HEX_BASE_SIZE;
 	}
-	kfs_write_char(&screen_context, base[hex], color);
+	kfs_write_char(&screen_context, base[hex]);
 }
 
 int print_f(char *str, ...)
@@ -49,7 +49,7 @@ int print_f(char *str, ...)
 		{
 			if (format[i + 1] == '\0') // Si % est le dernier caractère
 			{
-				kfs_write_char(&screen_context, '%', WHITE);
+				kfs_write_char(&screen_context, '%');
 				total_print++;
 				break;
 			}
@@ -57,34 +57,34 @@ int print_f(char *str, ...)
 			switch (format[i])
 			{
 				case '%': // Gestion de %%
-					kfs_write_char(&screen_context, '%', WHITE);
+					kfs_write_char(&screen_context, '%');
 					total_print++;
 					break;
 				case 'd':
-					total_print += print_number(*args++, WHITE);
+					total_print += print_number(*args++);
 					break;
 				case 's':
-					total_print += print_string(*((char **)args++), WHITE);
+					total_print += print_string(*((char **)args++));
 					break;
 				case 'c':
-					kfs_write_char(&screen_context, *args++, WHITE);
+					kfs_write_char(&screen_context, *args++);
 					total_print++;
 					break;
 				case 'x':
 					int count_hex = 0;
-					print_hex(*args++, WHITE);
+					print_hex(*args++);
 					total_print += count_hex;
 					break;
 				default:
-					kfs_write_char(&screen_context, '%', WHITE);
-					kfs_write_char(&screen_context, format[i], WHITE);
+					kfs_write_char(&screen_context, '%');
+					kfs_write_char(&screen_context, format[i]);
 					total_print += 2;
 					break;
 			}
 		}
 		else
 		{
-			kfs_write_char(&screen_context, format[i], WHITE);
+			kfs_write_char(&screen_context, format[i]);
 			total_print++;
 		}
 		i++;

--- a/part1/source/print_manager.h
+++ b/part1/source/print_manager.h
@@ -6,8 +6,8 @@
 #include "screen_manager.h"
 #include "utils.h"
 
-int	 print_number(int nb, unsigned char color);
-int	 print_string(char *str, unsigned char color);
+int print_number(int nb);
+int print_string(char *str);
 
 int print_f(char *str, ...);
 

--- a/part1/source/screen_manager.c
+++ b/part1/source/screen_manager.c
@@ -69,7 +69,7 @@ void set_cursor(t_screen_context *ctx, t_position pos)
 	ctx->desktops[ctx->desktop_index].cursor = pos;
 }
 
-void kfs_write_char(t_screen_context *ctx, unsigned char c, unsigned char color)
+void kfs_write_colored_char(t_screen_context *ctx, unsigned char c, unsigned char color)
 {
 	t_desktop *desktop = &ctx->desktops[ctx->desktop_index];
 
@@ -90,11 +90,26 @@ void kfs_write_char(t_screen_context *ctx, unsigned char c, unsigned char color)
 	}
 }
 
-void clear_screen(t_screen_context *ctx)
+void kfs_write_char(t_screen_context *ctx, unsigned char c)
+{
+	kfs_write_colored_char(ctx, c, ctx->color);
+}
+
+void clear_screen_colored(t_screen_context *ctx, unsigned char color)
 {
 	set_cursor(ctx, (t_position){0, 0});
 	for (int index = 0; index < SCREEN_CELLS_SIZE; index++)
 	{
-		kfs_write_char(ctx, ' ', WHITE);
+		kfs_write_colored_char(ctx, ' ', color);
 	}
+}
+
+void clear_screen(t_screen_context *ctx)
+{
+	clear_screen_colored(ctx, BLACK);
+}
+
+void set_color(t_screen_context *ctx, unsigned char color)
+{
+	ctx->color = color;
 }

--- a/part1/source/screen_manager.h
+++ b/part1/source/screen_manager.h
@@ -46,6 +46,8 @@ typedef struct s_screen_context
 	t_desktop	   desktops[DESKTOP_COUNT]; // private
 	unsigned int   desktop_index;			// private
 	unsigned char *vga_buffer;				// private
+
+	unsigned char color; // private
 } t_screen_context;
 
 extern t_screen_context screen_context;
@@ -54,7 +56,11 @@ extern t_screen_context screen_context;
 void init_screen_context(t_screen_context *ctx);
 
 // Main functions
-void kfs_write_char(t_screen_context *ctx, unsigned char c, unsigned char color);
+void kfs_write_colored_char(t_screen_context *ctx, unsigned char c, unsigned char color);
+void kfs_write_char(t_screen_context *ctx, unsigned char c);
 void clear_screen(t_screen_context *ctx);
+
+// Utility functions
+void set_color(t_screen_context *ctx, unsigned char color);
 
 #endif


### PR DESCRIPTION
ATTENTION BRANCHE BASÉÉ sur `refactor/screen_manager`

Refactor des couleurs

Dans l'API du screen manager, on peut mtn set_color avant un print pour sélectionner une couleur. Plutôt que de tout le temps passer en paramètre la couleur à chaque fonction de print